### PR TITLE
flattened out union and leaf lists for usage for easier db entries

### DIFF
--- a/gobind/README.md
+++ b/gobind/README.md
@@ -11,4 +11,11 @@ code expects the -o test.go and it will convert it to fmt_test.go.
 
 11/13/15 - Created initial structs, New method, and Set method for each member of the struct.  This is initial code generation and has not been tested.
 
+11/17/15 - File name inputed does not matter, a new file will be generated with prefix of fmt_xxxx
+Union and leaf-lists have been flattened out for purposes of being able to use the structs generated in a db fashion.
+
+code was run against openconfig interface
+pyang --plugindir ~/git/external/src/github.com/pyangbind/gobind -f pybind -o if.go *.yang
+
+
 


### PR DESCRIPTION
The package name expects a format of openconfig-XXXX for base name.  All augmented files should be named as a "subtype"   openconfig-XXXX-subtype for example.
